### PR TITLE
gen_boot.sh: fix error "mv: cannot move 'TR6560-bootimage.bin' to '..…

### DIFF
--- a/package/triductor/triboot/src/tools/gen_boot.sh
+++ b/package/triductor/triboot/src/tools/gen_boot.sh
@@ -10,6 +10,7 @@ dd if=/dev/zero ibs=1k count=200 | tr "\000" "\377" > fileFF.tmp;
 
 cat TR6560-bootimage_nodtb.bin fileFF.tmp  | head --bytes=$BOOT_FAC_LEN > TR6560-bootimage.bin.tmp;
 cat TR6560-bootimage.bin.tmp boot.dtb   > TR6560-bootimage.bin;
+mkdir -p ../bin
 mv TR6560-bootimage.bin ../bin/;
 
 rm -f  *.tmp;


### PR DESCRIPTION
this fixes build error:
```
mv: cannot move 'TR6560-bootimage.bin' to '../bin/': Not a directory
```